### PR TITLE
feat: update ingestion worker and backend

### DIFF
--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -161,7 +161,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| aiModels | object | `{"aws":{"bucketName":"","endpointUrl":"","existingSecret":{"accessKeyIdKey":"","name":"","secretAccessKeyKey":""}},"azure":{"managedIdentityClientId":"","storageAccountName":"","storageContainerName":"","tenantId":""},"azureml":{"clientId":"","clientSecret":"","existingSecret":{"clientIdKey":"","clientSecretKey":"","name":""},"resourceGroup":"","subscriptionId":"","tenantId":"","workspace":""},"gcp":{"bucketName":"","projectName":""},"modelActionClassifier":{"name":"action-classifier","version":"6"},"modelEmbedding":{"name":"embedding","version":"1"},"modelInferenceInteractions":{"name":"interaction-analyzer-7b-v2","version":"38"},"modelLanguageDetection":{"name":"language-detection","version":"2"},"modelPiiRemoval":{"name":"pii-removal","version":"2"},"modelTopicClassifier":{"name":"topic-classifier","version":"16"},"registry":"","sync":{"affinity":{},"enabled":false,"env":{},"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/nebuly-ai/nebuly-models-sync","tag":"v0.4.1"},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{"runAsNonRoot":true},"resources":{"limits":{"memory":"8Gi"},"requests":{"memory":"4Gi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true},"source":{"clientId":"","clientSecret":"","existingSecret":{"clientIdKey":"","clientSecretKey":"","name":""}},"tolerations":[],"volumeMounts":[],"volumes":[]}}` | Settings of the AI models used for inference. |
+| aiModels | object | `{"aws":{"bucketName":"","endpointUrl":"","existingSecret":{"accessKeyIdKey":"","name":"","secretAccessKeyKey":""}},"azure":{"managedIdentityClientId":"","storageAccountName":"","storageContainerName":"","tenantId":""},"azureml":{"clientId":"","clientSecret":"","existingSecret":{"clientIdKey":"","clientSecretKey":"","name":""},"resourceGroup":"","subscriptionId":"","tenantId":"","workspace":""},"gcp":{"bucketName":"","projectName":""},"modelActionClassifier":{"name":"action-classifier","version":"6"},"modelEmbedding":{"name":"embedding","version":"1"},"modelInferenceInteractions":{"name":"interaction-analyzer-7b-v2","version":"39"},"modelLanguageDetection":{"name":"language-detection","version":"2"},"modelPiiRemoval":{"name":"pii-removal","version":"7"},"modelTopicClassifier":{"name":"topic-classifier","version":"19"},"registry":"","sync":{"affinity":{},"enabled":false,"env":{},"image":{"pullPolicy":"IfNotPresent","repository":"ghcr.io/nebuly-ai/nebuly-models-sync","tag":"v0.4.1"},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{"runAsNonRoot":true},"resources":{"limits":{"memory":"8Gi"},"requests":{"memory":"4Gi"}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true},"source":{"clientId":"","clientSecret":"","existingSecret":{"clientIdKey":"","clientSecretKey":"","name":""}},"tolerations":[],"volumeMounts":[],"volumes":[]}}` | Settings of the AI models used for inference. |
 | aiModels.aws | object | - | Config of the AWS S3 model registry. |
 | aiModels.aws.bucketName | string | `""` | The name of the AWS S3 bucket. |
 | aiModels.aws.endpointUrl | string | `""` | Optional AWS S3 endpoint URL. The URL should not include the bucket name. Example: "https://my-domain.com:9444" |
@@ -284,7 +284,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backend.fullnameOverride | string | `""` |  |
 | backend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | backend.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-backend"` |  |
-| backend.image.tag | string | `"v1.104.6"` |  |
+| backend.image.tag | string | `"v1.106.6"` |  |
 | backend.ingress.annotations | object | `{}` |  |
 | backend.ingress.className | string | `""` |  |
 | backend.ingress.enabled | bool | `false` |  |
@@ -483,7 +483,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingestionWorker.healthCheckPath | string | `""` | Example: /mnt/health-check/healthy.timestamp |
 | ingestionWorker.image.pullPolicy | string | `"IfNotPresent"` |  |
 | ingestionWorker.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-ingestion-worker"` |  |
-| ingestionWorker.image.tag | string | `"v1.70.16"` |  |
+| ingestionWorker.image.tag | string | `"v1.71.9"` |  |
 | ingestionWorker.nodeSelector | object | `{}` |  |
 | ingestionWorker.numWorkersFeedbackActions | int | `10` | The number of workers (e.g. coroutines) used to process feedback actions. |
 | ingestionWorker.numWorkersInteractions | int | `10` | The number of workers (e.g. coroutines) used to process interactions. |
@@ -515,6 +515,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingestionWorker.settings.piiDenyList | list | `[]` | List of PII keywords to be ignored. You can insert names and addresses that you don't want the PII detection to remove. |
 | ingestionWorker.settings.piiEnabledTenants | list | `[]` | List of tenants for which PII detection is enabled. Note that when given this will override the enablePiiLlm setting for the given tenants. |
 | ingestionWorker.settings.startDateActions | string | `"2020-01-01 00:00:00+00:00"` | Start date used to consider existing actions. This feature should only be used to force the processing pipeline to ignore actions created before a given date.  |
+| ingestionWorker.settings.startDateSubTopics | string | `"2020-01-01 00:00:00+00:00"` | Start date used to consider existing sub-topics. This feature should only be used to force the processing pipeline to ignore sub-topics created before a given date. |
+| ingestionWorker.settings.startDateTopics | string | `"2020-01-01 00:00:00+00:00"` | Start date used to consider existing topics. This feature should only be used to force the processing pipeline to ignore topics created before a given date. |
 | ingestionWorker.settings.tasks | object | `{"feedbackAction":true,"interaction":true,"tags":true,"traceInteraction":true}` | Enable or disable internal worker tasks. This is primarily intended for debugging or performance tuning. |
 | ingestionWorker.settings.vLLMBatchSize | int | `512` | The mini-batch size used for the LLM inference. |
 | ingestionWorker.settings.vLLMBatchTimeout | int | `900` | The timeout in seconds for a single LLM batch inference. |

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -439,7 +439,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.fullnameOverride | string | `""` |  |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | frontend.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-frontend"` |  |
-| frontend.image.tag | string | `"v1.76.7"` |  |
+| frontend.image.tag | string | `"v1.76.10"` |  |
 | frontend.ingress.annotations | object | `{}` |  |
 | frontend.ingress.className | string | `""` |  |
 | frontend.ingress.enabled | bool | `false` |  |

--- a/nebuly-platform/templates/_ingestion_worker.tpl
+++ b/nebuly-platform/templates/_ingestion_worker.tpl
@@ -110,6 +110,10 @@
   value: {{ .Values.ingestionWorker.settings.categoryEngine | quote }}
 - name: MINIMUM_ACTION_DATE
   value: {{ .Values.ingestionWorker.settings.startDateActions | quote }}
+- name: MINIMUM_SUB_TOPIC_DATE
+  value: {{ .Values.ingestionWorker.settings.startDateSubTopics | quote }}
+- name: MINIMUM_TOPIC_DATE
+  value: {{ .Values.ingestionWorker.settings.startDateTopics | quote }}
 # Data retention
 - name: DATA_RETENTION_MAX_NUMBER_OF_DAYS
   value: {{ .Values.ingestionWorker.settings.dataRetentionDays | quote }}

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -187,7 +187,7 @@ frontend:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-frontend
     pullPolicy: IfNotPresent
-    tag: "v1.76.7"
+    tag: "v1.76.10"
 
   podAnnotations: { }
   podLabels: { }

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -22,7 +22,7 @@ backend:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-backend
     pullPolicy: IfNotPresent
-    tag: "v1.104.6"
+    tag: "v1.106.6"
 
   settings:
     multiTenancyMode: "dynamic_schema"
@@ -400,6 +400,12 @@ ingestionWorker:
     # -- Start date used to consider existing actions. This feature should only be used to force the
     # processing pipeline to ignore actions created before a given date. 
     startDateActions: "2020-01-01 00:00:00+00:00"
+    # -- Start date used to consider existing sub-topics. This feature should only be used to force the
+    # processing pipeline to ignore sub-topics created before a given date.
+    startDateSubTopics: "2020-01-01 00:00:00+00:00"
+    # -- Start date used to consider existing topics. This feature should only be used to force the
+    # processing pipeline to ignore topics created before a given date.
+    startDateTopics: "2020-01-01 00:00:00+00:00"
     # -- The name of the alembic table used to store the status of the ingestion worker
     # migrations. If not provided, the default `alembic_version` table will be used.
     alembicTable: ""
@@ -416,7 +422,7 @@ ingestionWorker:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-ingestion-worker
     pullPolicy: IfNotPresent
-    tag: v1.70.16
+    tag: v1.71.9
 
   podAnnotations: { }
   podLabels: { }
@@ -482,7 +488,7 @@ aiModels:
 
   modelInferenceInteractions:
     name: "interaction-analyzer-7b-v2"
-    version: "38"
+    version: "39"
   
   modelEmbedding:
     name: "embedding"
@@ -490,7 +496,7 @@ aiModels:
 
   modelTopicClassifier:
     name: "topic-classifier"
-    version: "16"
+    version: "19"
 
   modelActionClassifier:
     name: "action-classifier"
@@ -502,7 +508,7 @@ aiModels:
 
   modelPiiRemoval:
     name: "pii-removal"
-    version: "2"
+    version: "7"
 
   # -- Config of the AWS S3 model registry.
   # @default -- -
@@ -714,7 +720,7 @@ primaryProcessing:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-inference
     pullPolicy: IfNotPresent
-    tag: v1.70.16
+    tag: v1.71.9
 
   # -- Settings of the PVC used to cache AI models.
   modelsCache:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Primarily version bumps plus new ingestion-worker processing cutoffs; risk is moderate due to changing deployed binaries/models and potentially altering ingestion behavior based on the new date filters.
> 
> **Overview**
> Updates the Helm chart to deploy newer component images (backend `v1.106.6`, frontend `v1.76.10`, ingestion worker/inference `v1.71.9`) and bumps default AI model versions used for inference (interactions, topic classifier, and PII removal).
> 
> Adds two new ingestion-worker configuration knobs, `ingestionWorker.settings.startDateSubTopics` and `ingestionWorker.settings.startDateTopics`, and wires them into the pod environment as `MINIMUM_SUB_TOPIC_DATE` and `MINIMUM_TOPIC_DATE` to control minimum dates considered during processing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dd7778b92588d16ee6d91307a342390d039b109. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->