### PR TITLE
Update FE to fix export csv issue

### DIFF
--- a/nebuly-platform/Chart.yaml
+++ b/nebuly-platform/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.92.0
+version: 1.92.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -1,6 +1,6 @@
 # Nebuly Platform
 
-![Version: 1.92.0](https://img.shields.io/badge/Version-1.92.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.92.1](https://img.shields.io/badge/Version-1.92.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for installing Nebuly's Platform on Kubernetes.
 
@@ -447,7 +447,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.fullnameOverride | string | `""` |  |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | frontend.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-frontend"` |  |
-| frontend.image.tag | string | `"v1.77.4"` |  |
+| frontend.image.tag | string | `"v1.77.5"` |  |
 | frontend.ingress.annotations | object | `{}` |  |
 | frontend.ingress.className | string | `""` |  |
 | frontend.ingress.enabled | bool | `false` |  |

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -190,7 +190,7 @@ frontend:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-frontend
     pullPolicy: IfNotPresent
-    tag: "v1.77.4"
+    tag: "v1.77.5"
 
   podAnnotations: { }
   podLabels: { }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Helm metadata/value updates that only change the deployed frontend container version and chart patch version.
> 
> **Overview**
> Bumps the `nebuly-platform` Helm chart version from `1.92.0` to `1.92.1`.
> 
> Updates the default `frontend.image.tag` from `v1.77.4` to `v1.77.5` (and refreshes the README version badge/table accordingly), so installs/upgrades deploy the newer frontend image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b034082f124cb7a0dc7df48fcda1c7e7bac3d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->