### PR TITLE
fix: mcp server

### DIFF
--- a/nebuly-platform/Chart.yaml
+++ b/nebuly-platform/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.92.1
+version: 1.92.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -1,6 +1,6 @@
 # Nebuly Platform
 
-![Version: 1.92.1](https://img.shields.io/badge/Version-1.92.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.92.2](https://img.shields.io/badge/Version-1.92.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for installing Nebuly's Platform on Kubernetes.
 
@@ -491,7 +491,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingestionWorker.healthCheckPath | string | `""` | Example: /mnt/health-check/healthy.timestamp |
 | ingestionWorker.image.pullPolicy | string | `"IfNotPresent"` |  |
 | ingestionWorker.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-ingestion-worker"` |  |
-| ingestionWorker.image.tag | string | `"v1.73.4"` |  |
+| ingestionWorker.image.tag | string | `"v1.73.5"` |  |
 | ingestionWorker.nodeSelector | object | `{}` |  |
 | ingestionWorker.numWorkersFeedbackActions | int | `10` | The number of workers (e.g. coroutines) used to process feedback actions. |
 | ingestionWorker.numWorkersInteractions | int | `10` | The number of workers (e.g. coroutines) used to process interactions. |
@@ -596,7 +596,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | mcpServer.apiEndpoint | string | `""` | The API endpoint of the MCP server. This is the URL used by the MCP clients to connect to the server |
 | mcpServer.enabled | bool | `false` | If True, deploy the MCP server. |
 | mcpServer.fullnameOverride | string | `""` |  |
-| mcpServer.image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/nebuly-ai/nebuly-mcp-server","tag":"v0.1.0"}` | The image to use for the MCP server deployment. |
+| mcpServer.image | object | `{"pullPolicy":"IfNotPresent","repository":"ghcr.io/nebuly-ai/nebuly-mcp-server","tag":"v0.1.2"}` | The image to use for the MCP server deployment. |
 | mcpServer.ingress.annotations | object | `{}` |  |
 | mcpServer.ingress.className | string | `""` |  |
 | mcpServer.ingress.enabled | bool | `false` |  |

--- a/nebuly-platform/templates/mcp-server_deployment.yaml
+++ b/nebuly-platform/templates/mcp-server_deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: "MCP_SERVER_URL"
               value: {{ .Values.mcpServer.apiEndpoint | quote }}
             - name: "TENANT_REGISTRY_URL"
-              value: {{ .Values.frontend.authApiUrl | quote }}
+              value: {{ include "authService.url" . | quote }}
             - name: "AUTHORIZATION_SERVER_URL"
               value: {{ .Values.frontend.rootUrl | quote }}
             - name: "TENANT_REGISTRY_CLIENT_ID"

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -427,7 +427,7 @@ ingestionWorker:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-ingestion-worker
     pullPolicy: IfNotPresent
-    tag: v1.73.4
+    tag: v1.73.5
 
   podAnnotations: { }
   podLabels: { }
@@ -725,7 +725,7 @@ primaryProcessing:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-inference
     pullPolicy: IfNotPresent
-    tag: v1.73.4
+    tag: v1.73.5
 
   # -- Settings of the PVC used to cache AI models.
   modelsCache:
@@ -1886,7 +1886,7 @@ mcpServer:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-mcp-server
     pullPolicy: IfNotPresent
-    tag: "v0.1.0"
+    tag: "v0.1.2"
 
   # -- Service of the MCP server deployment.
   service:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the MCP server’s `TENANT_REGISTRY_URL` wiring and upgrades multiple deployed image tags, which could affect runtime connectivity/behavior if assumptions differ.
> 
> **Overview**
> Bumps the Helm chart version to `1.92.2` and updates referenced container images (`nebuly-ingestion-worker`/`nebuly-inference` to `v1.73.5`, `nebuly-mcp-server` to `v0.1.2`).
> 
> Fixes the MCP server Deployment to derive `TENANT_REGISTRY_URL` from the chart’s `authService.url` helper (instead of `frontend.authApiUrl`), aligning it with the in-cluster auth service endpoint, and updates the README version badge accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 637aa741068ad53cac3a0a1eb0ef4bcc8c8a9636. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->