### PR TITLE
fix: ingestion

### DIFF
--- a/nebuly-platform/Chart.yaml
+++ b/nebuly-platform/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.92.9
+version: 1.92.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -1,6 +1,6 @@
 # Nebuly Platform
 
-![Version: 1.92.9](https://img.shields.io/badge/Version-1.92.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.92.10](https://img.shields.io/badge/Version-1.92.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for installing Nebuly's Platform on Kubernetes.
 
@@ -291,7 +291,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backend.fullnameOverride | string | `""` |  |
 | backend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | backend.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-backend"` |  |
-| backend.image.tag | string | `"v1.108.7"` |  |
+| backend.image.tag | string | `"v1.108.9"` |  |
 | backend.ingress.annotations | object | `{}` |  |
 | backend.ingress.className | string | `""` |  |
 | backend.ingress.enabled | bool | `false` |  |
@@ -484,6 +484,12 @@ The command removes all the Kubernetes components associated with the chart and 
 | fullProcessing.hostIPC | bool | `false` | Set to True when running on multiple GPUs. |
 | fullProcessing.settings.processingDelaySeconds | int | `0` | Seconds of delay between processing. |
 | imagePullSecrets | list | `[]` |  |
+| ingestion.generateDbEvents.enabled | bool | `false` | If True, deploy a CronJob to generate DB events. The CronJob is suspended and configured to never run on schedule; it must be manually triggered. |
+| ingestion.generateDbEvents.endDate | string | `""` |  |
+| ingestion.generateDbEvents.resources.limits.memory | string | `"512Mi"` |  |
+| ingestion.generateDbEvents.resources.requests.cpu | string | `"50m"` |  |
+| ingestion.generateDbEvents.startDate | string | `""` |  |
+| ingestion.generateDbEvents.tenant | string | `""` |  |
 | ingestionWorker.affinity | object | `{}` |  |
 | ingestionWorker.deploymentStrategy.type | string | `"Recreate"` |  |
 | ingestionWorker.env | object | `{}` | Example: - name: MY_ENV_VAR   value: "my-value" |

--- a/nebuly-platform/templates/_helpers.tpl
+++ b/nebuly-platform/templates/_helpers.tpl
@@ -102,6 +102,12 @@ helm.sh/chart: {{ include "nebuly-platform.chart" . }}
 app.kubernetes.io/component: nebuly-backend
 {{- end }}
 
+{{- define "ingestion.generateDbEventsLabels" -}}
+{{- include "nebuly-platform.selectorLabels" . }}
+helm.sh/chart: {{ include "nebuly-platform.chart" . }}
+app.kubernetes.io/component: nebuly-backend
+{{- end }}
+
 {{/*
 *********************************************************************
 * Backend

--- a/nebuly-platform/templates/_validation.tpl
+++ b/nebuly-platform/templates/_validation.tpl
@@ -53,6 +53,10 @@
 {{- if .Values.interactionsAccessControl.enabled -}}
 {{- $messages = append $messages (include "chart.validateValues.interactionsAccessControl.mode" .) -}}
 {{- end -}}
+{{/* Generate DB Events */}}
+{{- if .Values.ingestion.generateDbEvents.enabled -}}
+{{- $messages = append $messages (include "chart.validateValues.ingestion.generateDbEvents" .) -}}
+{{- end -}}
 {{/* ClickHouse */}}
 {{- if .Values.clickhouse.enabled -}}
 {{- $messages = append $messages (include "chart.validateValues.clickhouse.replicas" .) -}}
@@ -320,6 +324,22 @@ values: backend.settings.multiTenancyMode
 {{- if not (contains .Values.interactionsAccessControl.openDetailsMode "disabled reason") -}}
 values: interactionsAccessControl.mode
   `mode` should be one of the following values: disabled, reason
+{{- end -}}
+{{- end -}}
+
+{{/* Generate DB Events validation. */}}
+{{- define "chart.validateValues.ingestion.generateDbEvents" -}}
+{{- if empty .Values.ingestion.generateDbEvents.tenant -}}
+values: ingestion.generateDbEvents.tenant
+  `tenant` is required when `ingestion.generateDbEvents.enabled` is true
+{{- end -}}
+{{- if empty .Values.ingestion.generateDbEvents.startDate -}}
+values: ingestion.generateDbEvents.startDate
+  `startDate` is required when `ingestion.generateDbEvents.enabled` is true
+{{- end -}}
+{{- if empty .Values.ingestion.generateDbEvents.endDate -}}
+values: ingestion.generateDbEvents.endDate
+  `endDate` is required when `ingestion.generateDbEvents.enabled` is true
 {{- end -}}
 {{- end -}}
 

--- a/nebuly-platform/templates/generate-db-events_cronjob.yaml
+++ b/nebuly-platform/templates/generate-db-events_cronjob.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.ingestion.generateDbEvents.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ printf "%s-generate-db-events" .Release.Name | trunc 63 | trimSuffix "-" }}
+  namespace: {{ include "nebuly-platform.namespace" . }}
+  labels:
+    {{- include "ingestion.generateDbEventsLabels" . | nindent 4 }}
+  annotations:
+    {{- include "nebuly-platform.annotations" . | nindent 4 }}
+spec:
+  schedule: 0 0 30 2 * # Never
+  suspend: true
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "ingestion.generateDbEventsLabels" . | nindent 8 }}
+    spec:
+      template:
+        metadata:
+          {{- with .Values.backend.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "ingestion.generateDbEventsLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ .Values.serviceAccount.name }}
+          securityContext:
+            {{- toYaml .Values.backend.podSecurityContext | nindent 12 }}
+          containers:
+            - name: backend
+              securityContext:
+                {{- toYaml .Values.backend.securityContext | nindent 16 }}
+              image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+              command:
+                - python
+                - scripts/db_event_generator.py
+                - --tenant
+                - {{ .Values.ingestion.generateDbEvents.tenant | quote }}
+                - --start-date
+                - {{ .Values.ingestion.generateDbEvents.startDate | quote }}
+                - --end-date
+                - {{ .Values.ingestion.generateDbEvents.endDate | quote }}
+              resources:
+                {{- toYaml .Values.ingestion.generateDbEvents.resources | nindent 16 }}
+              env:
+                {{- include "backend.commonEnv" . | nindent 16 }}
+              {{- with .Values.backend.volumeMounts }}
+              volumeMounts:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+          {{- with .Values.backend.volumes }}
+          volumes:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backend.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backend.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.backend.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end }}

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -22,7 +22,7 @@ backend:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-backend
     pullPolicy: IfNotPresent
-    tag: "v1.108.7"
+    tag: "v1.108.9"
 
   settings:
     multiTenancyMode: "dynamic_schema"
@@ -727,7 +727,7 @@ primaryProcessing:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-inference
     pullPolicy: IfNotPresent
-    tag: v1.73.7
+    tag: v1.73.8
 
   # -- Settings of the PVC used to cache AI models.
   modelsCache:
@@ -1373,6 +1373,22 @@ reprocessing:
     enabled: false
   userIntelligence:
     enabled: false
+ingestion:
+  generateDbEvents:
+    # -- If True, deploy a CronJob to generate DB events. The CronJob is suspended and
+    # configured to never run on schedule; it must be manually triggered.
+    enabled: false
+    # -- Required when enabled — passed as --tenant to scripts/db_event_generator.py.
+    tenant: ""
+    # -- Required when enabled — passed as --start-date (ISO datetime).
+    startDate: ""
+    # -- Required when enabled — passed as --end-date (ISO datetime).
+    endDate: ""
+    resources:
+      requests:
+        cpu: 50m
+      limits:
+        memory: 512Mi
 
 # -- Post-upgrade hooks settings.
 postUpgrade:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Enables a manual backend job that can write analytics data for a tenant over a configured window; misconfiguration or mistaken trigger could affect ingestion data, though it stays disabled by default.
> 
> **Overview**
> Adds an **opt-in** Helm path to run a **suspended, never-scheduled** CronJob that backfills or generates analytics DB events for a tenant and date range via the backend image’s `scripts/db_event_generator.py` (`ingestion.generateDbEvents`).
> 
> When enabled, install-time validation requires `tenant`, `startDate`, and `endDate`; the job reuses backend env, security context, and scheduling knobs. Chart **1.92.10** also bumps **nebuly-backend** to **v1.108.9** and **nebuly-inference** (primary processing) to **v1.73.8**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 384fd5d6a85a909942ace936bdfc84569d3d0c12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->