### PR TITLE
Increase DSHM size in processing jobs

### DIFF
--- a/nebuly-platform/CHANGELOG.md
+++ b/nebuly-platform/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v1.92.13
+
+### Features
+* Mount a memory-backed `/dev/shm` volume (default `1Gi`) on the full-processing deployment and the primary processing CronJobs. Configurable via `fullProcessing.shmSize` and `primaryProcessing.shmSize`.
+
 ## v1.83.0
 
 ### Features

--- a/nebuly-platform/CHANGELOG.md
+++ b/nebuly-platform/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 * Mount a memory-backed `/dev/shm` volume (default `1Gi`) on the full-processing deployment and the primary processing CronJobs. Configurable via `fullProcessing.shmSize` and `primaryProcessing.shmSize`.
+* Raise the open-file-descriptor soft limit (`ulimit -n`, default `50000`) for the full-processing deployment and the primary processing CronJobs. Configurable via `fullProcessing.nofileLimit` and `primaryProcessing.nofileLimit`.
 
 ## v1.83.0
 

--- a/nebuly-platform/Chart.yaml
+++ b/nebuly-platform/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.92.12
+version: 1.92.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -1,6 +1,6 @@
 # Nebuly Platform
 
-![Version: 1.92.12](https://img.shields.io/badge/Version-1.92.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.92.13](https://img.shields.io/badge/Version-1.92.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for installing Nebuly's Platform on Kubernetes.
 
@@ -477,7 +477,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.useFaviconAsLogo | bool | `false` |  |
 | frontend.volumeMounts | list | `[]` |  |
 | frontend.volumes | list | `[]` |  |
-| fullProcessing | object | `{"affinity":{},"deploymentStrategy":{"type":"Recreate"},"enabled":false,"env":{},"fullnameOverride":"","hostIPC":false,"modelsCache":{"enabled":false,"size":"128Gi","storageClassName":""},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{"fsGroup":101,"runAsNonRoot":true},"resources":{"limits":{"nvidia.com/gpu":1},"requests":{"cpu":1}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true},"settings":{"processingDelaySeconds":0},"tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}],"volumeMounts":[],"volumes":[]}` | Settings related to the runtime full-processing mode, which replaces the primary and secondary processing CronJobs with an always running Deployment. |
+| fullProcessing | object | `{"affinity":{},"deploymentStrategy":{"type":"Recreate"},"enabled":false,"env":{},"fullnameOverride":"","hostIPC":false,"modelsCache":{"enabled":false,"size":"128Gi","storageClassName":""},"nodeSelector":{},"nofileLimit":50000,"podAnnotations":{},"podLabels":{},"podSecurityContext":{"fsGroup":101,"runAsNonRoot":true},"resources":{"limits":{"nvidia.com/gpu":1},"requests":{"cpu":1}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true},"settings":{"processingDelaySeconds":0},"shmSize":"1Gi","tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}],"volumeMounts":[],"volumes":[]}` | Settings related to the runtime full-processing mode, which replaces the primary and secondary processing CronJobs with an always running Deployment. |
 | fullProcessing.enabled | bool | `false` | If true, replaces the processing CronJobs with an always running Deployment. |
 | fullProcessing.env | object | `{}` | Additional environment variables, in the standard Kubernetes format. Example: - name: MY_ENV_VAR   value: "my-value" |
 | fullProcessing.hostIPC | bool | `false` | Set to True when running on multiple GPUs. |

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -481,6 +481,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | fullProcessing.enabled | bool | `false` | If true, replaces the processing CronJobs with an always running Deployment. |
 | fullProcessing.env | object | `{}` | Additional environment variables, in the standard Kubernetes format. Example: - name: MY_ENV_VAR   value: "my-value" |
 | fullProcessing.hostIPC | bool | `false` | Set to True when running on multiple GPUs. |
+| fullProcessing.nofileLimit | int | `50000` | Soft limit for the maximum number of open file descriptors (`ulimit -n`) set before launching the process. Requires the container runtime/node hard limit (RLIMIT_NOFILE hard) to be at least this value. Set to empty/null to leave the default. |
 | fullProcessing.settings.processingDelaySeconds | int | `0` | Seconds of delay between processing. |
 | fullProcessing.shmSize | string | `"1Gi"` | Size of the memory-backed `/dev/shm` volume mounted in the full-processing pod. Required by the processing pipeline (e.g. LLM inference) that relies on shared memory. Note: a memory-backed emptyDir counts against the container memory limit. Set to empty/null to disable the volume. |
 | imagePullSecrets | list | `[]` |  |
@@ -652,6 +653,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | primaryProcessing.env | object | `{}` | Additional environment variables, in the standard Kubernetes format. Example: - name: MY_ENV_VAR   value: "my-value" |
 | primaryProcessing.hostIPC | bool | `false` | Set to True when running on multiple GPUs. |
 | primaryProcessing.modelsCache | object | `{"enabled":false,"size":"128Gi","storageClassName":""}` | Settings of the PVC used to cache AI models. |
+| primaryProcessing.nofileLimit | int | `50000` | Soft limit for the maximum number of open file descriptors (`ulimit -n`) set before launching the process. Requires the container runtime/node hard limit (RLIMIT_NOFILE hard) to be at least this value. Set to empty/null to leave the default. |
 | primaryProcessing.schedule | string | `"0 23 * * *"` | The schedule of the CronJob. The format is the same as the Kubernetes CronJob schedule. |
 | primaryProcessing.shmSize | string | `"1Gi"` | Size of the memory-backed `/dev/shm` volume mounted in the primary processing pods. Required by the processing pipeline (e.g. LLM inference) that relies on shared memory. Note: a memory-backed emptyDir counts against the container memory limit. Set to empty/null to disable the volume. |
 | primaryProcessing.timezone | string | `""` | The timezone of the CronJob. If not provided, the default timezone of the Kubernetes cluster will be used. |

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -482,6 +482,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | fullProcessing.env | object | `{}` | Additional environment variables, in the standard Kubernetes format. Example: - name: MY_ENV_VAR   value: "my-value" |
 | fullProcessing.hostIPC | bool | `false` | Set to True when running on multiple GPUs. |
 | fullProcessing.settings.processingDelaySeconds | int | `0` | Seconds of delay between processing. |
+| fullProcessing.shmSize | string | `"1Gi"` | Size of the memory-backed `/dev/shm` volume mounted in the full-processing pod. Required by the processing pipeline (e.g. LLM inference) that relies on shared memory. Note: a memory-backed emptyDir counts against the container memory limit. Set to empty/null to disable the volume. |
 | imagePullSecrets | list | `[]` |  |
 | ingestion.generateDbEvents.enabled | bool | `false` | If True, deploy a CronJob to generate DB events. The CronJob is suspended and configured to never run on schedule; it must be manually triggered. |
 | ingestion.generateDbEvents.endDate | string | `""` |  |
@@ -652,6 +653,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | primaryProcessing.hostIPC | bool | `false` | Set to True when running on multiple GPUs. |
 | primaryProcessing.modelsCache | object | `{"enabled":false,"size":"128Gi","storageClassName":""}` | Settings of the PVC used to cache AI models. |
 | primaryProcessing.schedule | string | `"0 23 * * *"` | The schedule of the CronJob. The format is the same as the Kubernetes CronJob schedule. |
+| primaryProcessing.shmSize | string | `"1Gi"` | Size of the memory-backed `/dev/shm` volume mounted in the primary processing pods. Required by the processing pipeline (e.g. LLM inference) that relies on shared memory. Note: a memory-backed emptyDir counts against the container memory limit. Set to empty/null to disable the volume. |
 | primaryProcessing.timezone | string | `""` | The timezone of the CronJob. If not provided, the default timezone of the Kubernetes cluster will be used. |
 | redis.auth | object | `{"password":"nebuly"}` | Password for the Redis instance. |
 | redis.enabled | bool | `false` | If True, deploy a Redis instance together with the platform services. |

--- a/nebuly-platform/templates/_batch_jobs.tpl
+++ b/nebuly-platform/templates/_batch_jobs.tpl
@@ -66,3 +66,19 @@
 - name: ENABLE_ENRICH_CONVERSATION
   value: "false"
 {{- end -}}
+
+{{- define "primaryProcessing.shmVolumeMount" -}}
+{{- if .Values.primaryProcessing.shmSize }}
+- name: dshm
+  mountPath: /dev/shm
+{{- end }}
+{{- end -}}
+
+{{- define "primaryProcessing.shmVolume" -}}
+{{- if .Values.primaryProcessing.shmSize }}
+- name: dshm
+  emptyDir:
+    medium: Memory
+    sizeLimit: {{ .Values.primaryProcessing.shmSize }}
+{{- end }}
+{{- end -}}

--- a/nebuly-platform/templates/full-processing_deployment.yaml
+++ b/nebuly-platform/templates/full-processing_deployment.yaml
@@ -66,6 +66,10 @@ spec:
             - name: models-cache
               mountPath: /var/cache/nebuly
               readOnly: false
+          {{- if .Values.fullProcessing.shmSize }}
+            - name: dshm
+              mountPath: /dev/shm
+          {{- end }}
           {{- if not .Values.kafka.external }}
             - name: kafka-cluster-ca-cert
               mountPath: "/etc/kafka"
@@ -84,6 +88,12 @@ spec:
             claimName: {{ include "fullProcessing.modelsCache.name" . }}
       {{- else }}
           emptyDir: { }
+      {{- end }}
+      {{- if .Values.fullProcessing.shmSize }}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: {{ .Values.fullProcessing.shmSize }}
       {{- end }}
       {{- if not .Values.kafka.external }}
         - name: kafka-cluster-ca-cert

--- a/nebuly-platform/templates/full-processing_deployment.yaml
+++ b/nebuly-platform/templates/full-processing_deployment.yaml
@@ -40,6 +40,12 @@ spec:
           securityContext:
             {{- toYaml .Values.fullProcessing.securityContext | nindent 12 }}
           command:
+          {{- if .Values.fullProcessing.nofileLimit }}
+            - sh
+            - -c
+            - "ulimit -n {{ .Values.fullProcessing.nofileLimit }}; exec \"$@\""
+            - "--"
+          {{- end }}
             - python
             - entrypoints/entrypoint_loop_jobs.py
           image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"

--- a/nebuly-platform/templates/primary-process-all_cronjob.yaml
+++ b/nebuly-platform/templates/primary-process-all_cronjob.yaml
@@ -46,7 +46,15 @@ spec:
               securityContext:
                 {{- toYaml .Values.primaryProcessing.securityContext | nindent 16 }}
               image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"
-              command: [ "python", "jobs/process_all.py" ]
+              command:
+              {{- if .Values.primaryProcessing.nofileLimit }}
+                - sh
+                - -c
+                - "ulimit -n {{ .Values.primaryProcessing.nofileLimit }}; exec \"$@\""
+                - "--"
+              {{- end }}
+                - python
+                - jobs/process_all.py
               imagePullPolicy: {{ .Values.primaryProcessing.image.pullPolicy }}
               env:
               {{- if .Values.primaryProcessing.env }}

--- a/nebuly-platform/templates/primary-process-all_cronjob.yaml
+++ b/nebuly-platform/templates/primary-process-all_cronjob.yaml
@@ -67,6 +67,7 @@ spec:
                 - name: models-cache
                   mountPath: /var/cache/nebuly
                   readOnly: false
+              {{- include "primaryProcessing.shmVolumeMount" . | nindent 16 }}
               {{- with .Values.primaryProcessing.volumeMounts }}
                 {{- toYaml . | nindent 18 }}
               {{- end }}
@@ -85,6 +86,7 @@ spec:
           {{- else }}
               emptyDir: { }
           {{- end }}
+          {{- include "primaryProcessing.shmVolume" . | nindent 12 }}
           {{- with .Values.primaryProcessing.volumes }}
             {{- toYaml . | nindent 14 }}
           {{- end }}

--- a/nebuly-platform/templates/reprocess-interactions_cronjob.yaml
+++ b/nebuly-platform/templates/reprocess-interactions_cronjob.yaml
@@ -45,6 +45,12 @@ spec:
                 {{- toYaml .Values.primaryProcessing.securityContext | nindent 16 }}
               image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"
               command:
+              {{- if .Values.primaryProcessing.nofileLimit }}
+                - sh
+                - -c
+                - "ulimit -n {{ .Values.primaryProcessing.nofileLimit }}; exec \"$@\""
+                - "--"
+              {{- end }}
                 - python
                 - minkmaze
                 - jobs

--- a/nebuly-platform/templates/reprocess-interactions_cronjob.yaml
+++ b/nebuly-platform/templates/reprocess-interactions_cronjob.yaml
@@ -71,6 +71,7 @@ spec:
                 - name: models-cache
                   mountPath: /var/cache/nebuly
                   readOnly: false
+              {{- include "primaryProcessing.shmVolumeMount" . | nindent 16 }}
               {{- with .Values.primaryProcessing.volumeMounts }}
                 {{- toYaml . | nindent 18 }}
               {{- end }}
@@ -89,6 +90,7 @@ spec:
           {{- else }}
               emptyDir: { }
           {{- end }}
+          {{- include "primaryProcessing.shmVolume" . | nindent 12 }}
           {{- with .Values.primaryProcessing.volumes }}
             {{- toYaml . | nindent 14 }}
           {{- end }}

--- a/nebuly-platform/templates/reprocess-model-issues_cronjob.yaml
+++ b/nebuly-platform/templates/reprocess-model-issues_cronjob.yaml
@@ -45,6 +45,12 @@ spec:
                 {{- toYaml .Values.primaryProcessing.securityContext | nindent 16 }}
               image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"
               command:
+              {{- if .Values.primaryProcessing.nofileLimit }}
+                - sh
+                - -c
+                - "ulimit -n {{ .Values.primaryProcessing.nofileLimit }}; exec \"$@\""
+                - "--"
+              {{- end }}
                 - python
                 - minkmaze
                 - process

--- a/nebuly-platform/templates/reprocess-model-issues_cronjob.yaml
+++ b/nebuly-platform/templates/reprocess-model-issues_cronjob.yaml
@@ -70,6 +70,7 @@ spec:
                 - name: models-cache
                   mountPath: /var/cache/nebuly
                   readOnly: false
+              {{- include "primaryProcessing.shmVolumeMount" . | nindent 16 }}
               {{- with .Values.primaryProcessing.volumeMounts }}
                 {{- toYaml . | nindent 18 }}
               {{- end }}
@@ -88,6 +89,7 @@ spec:
           {{- else }}
               emptyDir: { }
           {{- end }}
+          {{- include "primaryProcessing.shmVolume" . | nindent 12 }}
           {{- with .Values.primaryProcessing.volumes }}
             {{- toYaml . | nindent 14 }}
           {{- end }}

--- a/nebuly-platform/templates/reprocess-model-suggestions_cronjob.yaml
+++ b/nebuly-platform/templates/reprocess-model-suggestions_cronjob.yaml
@@ -45,6 +45,12 @@ spec:
                 {{- toYaml .Values.primaryProcessing.securityContext | nindent 16 }}
               image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"
               command:
+              {{- if .Values.primaryProcessing.nofileLimit }}
+                - sh
+                - -c
+                - "ulimit -n {{ .Values.primaryProcessing.nofileLimit }}; exec \"$@\""
+                - "--"
+              {{- end }}
                 - python
                 - minkmaze
                 - jobs

--- a/nebuly-platform/templates/reprocess-model-suggestions_cronjob.yaml
+++ b/nebuly-platform/templates/reprocess-model-suggestions_cronjob.yaml
@@ -71,6 +71,7 @@ spec:
                 - name: models-cache
                   mountPath: /var/cache/nebuly
                   readOnly: false
+              {{- include "primaryProcessing.shmVolumeMount" . | nindent 16 }}
               {{- with .Values.primaryProcessing.volumeMounts }}
                 {{- toYaml . | nindent 18 }}
               {{- end }}
@@ -89,6 +90,7 @@ spec:
           {{- else }}
               emptyDir: { }
           {{- end }}
+          {{- include "primaryProcessing.shmVolume" . | nindent 12 }}
           {{- with .Values.primaryProcessing.volumes }}
             {{- toYaml . | nindent 14 }}
           {{- end }}

--- a/nebuly-platform/templates/reprocess-user-intelligence_cronjob.yaml
+++ b/nebuly-platform/templates/reprocess-user-intelligence_cronjob.yaml
@@ -45,6 +45,12 @@ spec:
                 {{- toYaml .Values.primaryProcessing.securityContext | nindent 16 }}
               image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"
               command:
+              {{- if .Values.primaryProcessing.nofileLimit }}
+                - sh
+                - -c
+                - "ulimit -n {{ .Values.primaryProcessing.nofileLimit }}; exec \"$@\""
+                - "--"
+              {{- end }}
                 - python
                 - minkmaze
                 - jobs

--- a/nebuly-platform/templates/reprocess-user-intelligence_cronjob.yaml
+++ b/nebuly-platform/templates/reprocess-user-intelligence_cronjob.yaml
@@ -71,6 +71,7 @@ spec:
                 - name: models-cache
                   mountPath: /var/cache/nebuly
                   readOnly: false
+              {{- include "primaryProcessing.shmVolumeMount" . | nindent 16 }}
               {{- with .Values.primaryProcessing.volumeMounts }}
                 {{- toYaml . | nindent 18 }}
               {{- end }}
@@ -89,6 +90,7 @@ spec:
           {{- else }}
               emptyDir: { }
           {{- end }}
+          {{- include "primaryProcessing.shmVolume" . | nindent 12 }}
           {{- with .Values.primaryProcessing.volumes }}
             {{- toYaml . | nindent 14 }}
           {{- end }}

--- a/nebuly-platform/templates/reset-interactions_cronjob.yaml
+++ b/nebuly-platform/templates/reset-interactions_cronjob.yaml
@@ -45,6 +45,12 @@ spec:
                 {{- toYaml .Values.primaryProcessing.securityContext | nindent 16 }}
               image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"
               command:
+              {{- if .Values.primaryProcessing.nofileLimit }}
+                - sh
+                - -c
+                - "ulimit -n {{ .Values.primaryProcessing.nofileLimit }}; exec \"$@\""
+                - "--"
+              {{- end }}
                 - python
                 - minkmaze
                 - jobs

--- a/nebuly-platform/templates/reset-interactions_cronjob.yaml
+++ b/nebuly-platform/templates/reset-interactions_cronjob.yaml
@@ -71,6 +71,7 @@ spec:
                 - name: models-cache
                   mountPath: /var/cache/nebuly
                   readOnly: false
+              {{- include "primaryProcessing.shmVolumeMount" . | nindent 16 }}
               {{- with .Values.primaryProcessing.volumeMounts }}
                 {{- toYaml . | nindent 18 }}
               {{- end }}
@@ -89,6 +90,7 @@ spec:
           {{- else }}
               emptyDir: { }
           {{- end }}
+          {{- include "primaryProcessing.shmVolume" . | nindent 12 }}
           {{- with .Values.primaryProcessing.volumes }}
             {{- toYaml . | nindent 14 }}
           {{- end }}

--- a/nebuly-platform/templates/reset-model-suggestion_cronjob.yaml
+++ b/nebuly-platform/templates/reset-model-suggestion_cronjob.yaml
@@ -45,6 +45,12 @@ spec:
                 {{- toYaml .Values.primaryProcessing.securityContext | nindent 16 }}
               image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"
               command:
+              {{- if .Values.primaryProcessing.nofileLimit }}
+                - sh
+                - -c
+                - "ulimit -n {{ .Values.primaryProcessing.nofileLimit }}; exec \"$@\""
+                - "--"
+              {{- end }}
                 - python
                 - minkmaze
                 - jobs

--- a/nebuly-platform/templates/reset-model-suggestion_cronjob.yaml
+++ b/nebuly-platform/templates/reset-model-suggestion_cronjob.yaml
@@ -71,6 +71,7 @@ spec:
                 - name: models-cache
                   mountPath: /var/cache/nebuly
                   readOnly: false
+              {{- include "primaryProcessing.shmVolumeMount" . | nindent 16 }}
               {{- with .Values.primaryProcessing.volumeMounts }}
                 {{- toYaml . | nindent 18 }}
               {{- end }}
@@ -89,6 +90,7 @@ spec:
           {{- else }}
               emptyDir: { }
           {{- end }}
+          {{- include "primaryProcessing.shmVolume" . | nindent 12 }}
           {{- with .Values.primaryProcessing.volumes }}
             {{- toYaml . | nindent 14 }}
           {{- end }}

--- a/nebuly-platform/templates/reset-user-intelligence_cronjob.yaml
+++ b/nebuly-platform/templates/reset-user-intelligence_cronjob.yaml
@@ -45,6 +45,12 @@ spec:
                 {{- toYaml .Values.primaryProcessing.securityContext | nindent 16 }}
               image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"
               command:
+              {{- if .Values.primaryProcessing.nofileLimit }}
+                - sh
+                - -c
+                - "ulimit -n {{ .Values.primaryProcessing.nofileLimit }}; exec \"$@\""
+                - "--"
+              {{- end }}
                 - python
                 - minkmaze
                 - jobs

--- a/nebuly-platform/templates/reset-user-intelligence_cronjob.yaml
+++ b/nebuly-platform/templates/reset-user-intelligence_cronjob.yaml
@@ -71,6 +71,7 @@ spec:
                 - name: models-cache
                   mountPath: /var/cache/nebuly
                   readOnly: false
+              {{- include "primaryProcessing.shmVolumeMount" . | nindent 16 }}
               {{- with .Values.primaryProcessing.volumeMounts }}
                 {{- toYaml . | nindent 18 }}
               {{- end }}
@@ -89,6 +90,7 @@ spec:
           {{- else }}
               emptyDir: { }
           {{- end }}
+          {{- include "primaryProcessing.shmVolume" . | nindent 12 }}
           {{- with .Values.primaryProcessing.volumes }}
             {{- toYaml . | nindent 14 }}
           {{- end }}

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -694,6 +694,11 @@ fullProcessing:
   # empty/null to disable the volume.
   shmSize: 1Gi
 
+  # -- Soft limit for the maximum number of open file descriptors (`ulimit -n`) set
+  # before launching the process. Requires the container runtime/node hard limit
+  # (RLIMIT_NOFILE hard) to be at least this value. Set to empty/null to leave the default.
+  nofileLimit: 50000
+
   podSecurityContext:
     runAsNonRoot: true
     fsGroup: 101
@@ -771,6 +776,11 @@ primaryProcessing:
   # Note: a memory-backed emptyDir counts against the container memory limit. Set to
   # empty/null to disable the volume.
   shmSize: 1Gi
+
+  # -- Soft limit for the maximum number of open file descriptors (`ulimit -n`) set
+  # before launching the process. Requires the container runtime/node hard limit
+  # (RLIMIT_NOFILE hard) to be at least this value. Set to empty/null to leave the default.
+  nofileLimit: 50000
 
   resources:
     requests:

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -688,6 +688,12 @@ fullProcessing:
   #   mountPath: "/etc/foo"
   #   readOnly: true
 
+  # -- Size of the memory-backed `/dev/shm` volume mounted in the full-processing pod.
+  # Required by the processing pipeline (e.g. LLM inference) that relies on shared memory.
+  # Note: a memory-backed emptyDir counts against the container memory limit. Set to
+  # empty/null to disable the volume.
+  shmSize: 1Gi
+
   podSecurityContext:
     runAsNonRoot: true
     fsGroup: 101
@@ -759,6 +765,12 @@ primaryProcessing:
   # - name: foo
   #   mountPath: "/etc/foo"
   #   readOnly: true
+
+  # -- Size of the memory-backed `/dev/shm` volume mounted in the primary processing pods.
+  # Required by the processing pipeline (e.g. LLM inference) that relies on shared memory.
+  # Note: a memory-backed emptyDir counts against the container memory limit. Set to
+  # empty/null to disable the volume.
+  shmSize: 1Gi
 
   resources:
     requests:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Operational change to GPU/LLM processing pods: memory-backed shm consumes container memory limits, and ulimit only works if the node hard RLIMIT_NOFILE is high enough—misconfiguration can cause OOM or startup failures.
> 
> **Overview**
> Helm chart **v1.92.13** tunes **full-processing** and **primary processing** workloads for LLM-style pipelines by adding configurable **shared memory** and **file-descriptor** limits.
> 
> Processing pods now mount a memory-backed **`/dev/shm`** volume (default **`1Gi`**, via `fullProcessing.shmSize` / `primaryProcessing.shmSize`; disable by clearing the value). Primary CronJobs share this through new `primaryProcessing.shmVolume` / `shmVolumeMount` partials; full-processing inlines the same `dshm` emptyDir.
> 
> Container **commands** optionally wrap the Python entrypoint in `sh -c` to run **`ulimit -n`** (default **50000**, `nofileLimit`) before `exec`, on the full-processing deployment and all primary/reprocess/reset CronJobs that use those settings.
> 
> Docs/changelog/README reflect the new values; behavior is otherwise unchanged except for these runtime limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d90247baec58674f9287b8ae5874c78597eba38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->