### PR TITLE
chore: bump backend to v1.112.6 and frontend to v1.78.1

### DIFF
--- a/nebuly-platform/Chart.yaml
+++ b/nebuly-platform/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.94.1
+version: 1.94.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -1,6 +1,6 @@
 # Nebuly Platform
 
-![Version: 1.94.1](https://img.shields.io/badge/Version-1.94.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.94.2](https://img.shields.io/badge/Version-1.94.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for installing Nebuly's Platform on Kubernetes.
 

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -290,7 +290,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | backend.fullnameOverride | string | `""` |  |
 | backend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | backend.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-backend"` |  |
-| backend.image.tag | string | `"v1.112.3"` |  |
+| backend.image.tag | string | `"v1.112.6"` |  |
 | backend.ingress.annotations | object | `{}` |  |
 | backend.ingress.className | string | `""` |  |
 | backend.ingress.enabled | bool | `false` |  |
@@ -446,7 +446,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.fullnameOverride | string | `""` |  |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | frontend.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-frontend"` |  |
-| frontend.image.tag | string | `"v1.78.0"` |  |
+| frontend.image.tag | string | `"v1.78.1"` |  |
 | frontend.ingress.annotations | object | `{}` |  |
 | frontend.ingress.className | string | `""` |  |
 | frontend.ingress.enabled | bool | `false` |  |

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -22,7 +22,7 @@ backend:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-backend
     pullPolicy: IfNotPresent
-    tag: "v1.112.3"
+    tag: "v1.112.6"
 
   settings:
     multiTenancyMode: "dynamic_schema"
@@ -190,7 +190,7 @@ frontend:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-frontend
     pullPolicy: IfNotPresent
-    tag: "v1.78.0"
+    tag: "v1.78.1"
 
   podAnnotations: { }
   podLabels: { }


### PR DESCRIPTION
## Summary
- Bump `nebuly-backend` image tag to `v1.112.6`
- Bump `nebuly-frontend` image tag to `v1.78.1`
- Regenerate Helm chart docs (`make doc` in `nebuly-platform/`)

## Test plan
- [ ] Verify rendered manifests use the updated image tags
- [ ] Deploy to a staging environment and confirm backend/frontend pods pull the new versions


Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nebuly-ai/codesmith/helm-charts/pr/193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784474384&installation_id=139603015&pr_number=193&repository=nebuly-ai%2Fhelm-charts&return_to=https%3A%2F%2Fgithub.com%2Fnebuly-ai%2Fhelm-charts%2Fpull%2F193&signature=ce9a38de674c7b177739eef16f554f0401fadd38117a735f63e07adc16a8c7e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->