### PR TITLE
feat: add frontend v2

### DIFF
--- a/nebuly-platform/Chart.yaml
+++ b/nebuly-platform/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.96.2
+version: 1.97.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -475,7 +475,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.title | string | `"Nebuly"` | The title of the application. |
 | frontend.tolerations | list | `[]` |  |
 | frontend.useFaviconAsLogo | bool | `false` |  |
-| frontend.v2.enabled | bool | `true` | If true, enable the v1 of the frontend. This will create a separate deployment for the v1 of the frontend, which will run alongside the default one. The v1 of the frontend is used for testing new features and for gradual rollouts. |
+| frontend.v2.enabled | bool | `true` | This will create a separate deployment, which will run alongside the default one. |
 | frontend.v2.image.pullPolicy | string | `"IfNotPresent"` |  |
 | frontend.v2.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-frontend"` |  |
 | frontend.v2.image.tag | string | `"v2.2.8"` |  |

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -1,6 +1,6 @@
 # Nebuly Platform
 
-![Version: 1.96.2](https://img.shields.io/badge/Version-1.96.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.97.0](https://img.shields.io/badge/Version-1.97.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for installing Nebuly's Platform on Kubernetes.
 
@@ -446,7 +446,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.fullnameOverride | string | `""` |  |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` |  |
 | frontend.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-frontend"` |  |
-| frontend.image.tag | string | `"v1.80.1"` |  |
+| frontend.image.tag | string | `"v1.80.2"` |  |
 | frontend.ingress.annotations | object | `{}` |  |
 | frontend.ingress.className | string | `""` |  |
 | frontend.ingress.enabled | bool | `false` |  |
@@ -475,6 +475,10 @@ The command removes all the Kubernetes components associated with the chart and 
 | frontend.title | string | `"Nebuly"` | The title of the application. |
 | frontend.tolerations | list | `[]` |  |
 | frontend.useFaviconAsLogo | bool | `false` |  |
+| frontend.v2.enabled | bool | `true` | If true, enable the v1 of the frontend. This will create a separate deployment for the v1 of the frontend, which will run alongside the default one. The v1 of the frontend is used for testing new features and for gradual rollouts. |
+| frontend.v2.image.pullPolicy | string | `"IfNotPresent"` |  |
+| frontend.v2.image.repository | string | `"ghcr.io/nebuly-ai/nebuly-frontend"` |  |
+| frontend.v2.image.tag | string | `"v2.2.8"` |  |
 | frontend.volumeMounts | list | `[]` |  |
 | frontend.volumes | list | `[]` |  |
 | fullProcessing | object | `{"affinity":{},"deploymentStrategy":{"type":"Recreate"},"enabled":false,"env":{},"fullnameOverride":"","hostIPC":false,"modelsCache":{"enabled":false,"size":"128Gi","storageClassName":""},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{"fsGroup":101,"runAsNonRoot":true},"resources":{"limits":{"nvidia.com/gpu":1},"requests":{"cpu":1}},"securityContext":{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"runAsNonRoot":true},"settings":{"processingDelaySeconds":0},"shmSize":"1Gi","tolerations":[{"effect":"NoSchedule","key":"nvidia.com/gpu","operator":"Exists"}],"volumeMounts":[],"volumes":[]}` | Settings related to the runtime full-processing mode, which replaces the primary and secondary processing CronJobs with an always running Deployment. |

--- a/nebuly-platform/templates/_backend.tpl
+++ b/nebuly-platform/templates/_backend.tpl
@@ -158,7 +158,7 @@
   value: "{{ .Values.backend.rootPath }}"
 {{- end }}
 - name: CORS_ALLOW_ORIGINS
-  value: {{ append .Values.auth.corsAllowOrigins (printf "https://v2.%s" (index .Values.auth.ingress.hosts 0).host) | toJson | quote }}
+  value: {{ append .Values.backend.corsAllowOrigins (include "frontend.v2.url" .) | toJson | quote }}
 {{- if and .Values.clickhouse.enabled .Values.clickhouse.active }}
 - name: CLICKHOUSE_ENABLED
   value: "true"

--- a/nebuly-platform/templates/_backend.tpl
+++ b/nebuly-platform/templates/_backend.tpl
@@ -199,5 +199,5 @@
 - name: PLATFORM_VERSION
   value: {{ printf "v%s" .Chart.Version | quote }}
 - name: APP_URL
-  value: {{ include "frontend.v2.url" . | quote }}
+  value: {{ if .Values.frontend.v2.enabled }}{{ include "frontend.v2.url" . | quote }}{{ else }}{{ .Values.frontend.rootUrl | quote }}{{ end }}
 {{- end -}}

--- a/nebuly-platform/templates/_backend.tpl
+++ b/nebuly-platform/templates/_backend.tpl
@@ -157,10 +157,8 @@
 - name: ROOT_PATH
   value: "{{ .Values.backend.rootPath }}"
 {{- end }}
-{{- if .Values.backend.corsAllowOrigins }}
 - name: CORS_ALLOW_ORIGINS
-  value: {{ .Values.backend.corsAllowOrigins | toJson | quote }}
-{{- end }}
+  value: {{ append .Values.auth.corsAllowOrigins (printf "https://v2.%s" (index .Values.auth.ingress.hosts 0).host) | toJson | quote }}
 {{- if and .Values.clickhouse.enabled .Values.clickhouse.active }}
 - name: CLICKHOUSE_ENABLED
   value: "true"
@@ -201,5 +199,5 @@
 - name: PLATFORM_VERSION
   value: {{ printf "v%s" .Chart.Version | quote }}
 - name: APP_URL
-  value: {{ .Values.frontend.rootUrl | quote }}
+  value: {{ include "frontend.v2.url" . | quote }}
 {{- end -}}

--- a/nebuly-platform/templates/_helpers.tpl
+++ b/nebuly-platform/templates/_helpers.tpl
@@ -312,6 +312,19 @@ app.kubernetes.io/component: nebuly-frontend
 http://{{ include "frontend.fullname" . }}.{{ include "nebuly-platform.namespace" . }}.svc.cluster.local:{{ .Values.frontend.service.port }}
 {{- end }}
 
+{{- define "frontend.v2.url" -}}
+https://v2.{{ (index .Values.frontend.ingress.hosts 0).host }}
+{{- end }}
+
+{{- define "frontend-v2.labels" -}}
+{{- include "frontend-v2.selectorLabels" . }}
+{{- end }}
+
+{{- define "frontend-v2.selectorLabels" -}}
+{{- include "nebuly-platform.selectorLabels" . }}
+app.kubernetes.io/component: nebuly-frontend-v2
+{{- end }}
+
 {{- define "frontend.fullname" -}}
 {{- if .Values.frontend.fullnameOverride }}
 {{- .Values.frontend.fullnameOverride | trunc 63 | trimSuffix "-" }}

--- a/nebuly-platform/templates/auth-service_deployment.yaml
+++ b/nebuly-platform/templates/auth-service_deployment.yaml
@@ -101,7 +101,7 @@ spec:
             # CORS
             {{- if .Values.auth.corsAllowOrigins }}
             - name: CORS_ALLOW_ORIGINS
-              value: {{ append .Values.auth.corsAllowOrigins (printf "https://v2.%s" (index .Values.auth.ingress.hosts 0).host) | toJson | quote }}
+              value: {{ append .Values.auth.corsAllowOrigins (include "frontend.v2.url" .) | toJson | quote }}
             {{- end }}
             # Auth
             - name: "JWT_SIGNING_KEY_PATH"

--- a/nebuly-platform/templates/auth-service_deployment.yaml
+++ b/nebuly-platform/templates/auth-service_deployment.yaml
@@ -101,7 +101,7 @@ spec:
             # CORS
             {{- if .Values.auth.corsAllowOrigins }}
             - name: CORS_ALLOW_ORIGINS
-              value: {{ .Values.auth.corsAllowOrigins | toJson | quote }}
+              value: {{ append .Values.auth.corsAllowOrigins (printf "https://v2.%s" (index .Values.auth.ingress.hosts 0).host) | toJson | quote }}
             {{- end }}
             # Auth
             - name: "JWT_SIGNING_KEY_PATH"

--- a/nebuly-platform/templates/frontend_configmap.yaml
+++ b/nebuly-platform/templates/frontend_configmap.yaml
@@ -52,6 +52,10 @@ data:
       "NEXT_PUBLIC_ENABLE_CUSTOM_VARIABLES": {{ .Values.frontend.enableCustomVariables | quote }},
       "NEXT_PUBLIC_ENABLE_USER_ANONYMIZATION": {{ .Values.backend.settings.enableUserAnonymization | quote }},
       "NEXT_PUBLIC_ENABLE_REMOTE_ACCESS" : {{ .Values.remoteAccess.enabled | quote }},
-      "NEXT_PUBLIC_ENABLE_ADMIN_EXPORT_LOGS": {{ .Values.loki.enabled | quote }}
+      "NEXT_PUBLIC_ENABLE_ADMIN_EXPORT_LOGS": {{ .Values.loki.enabled | quote }}{{- if .Values.frontend.v2.enabled }},{{ end }}
+      {{- if .Values.frontend.v2.enabled }}
+      "NEXT_URL": "https://v2.{{ (index .Values.frontend.ingress.hosts 0).host }}",
+      "NEXT_LEGACY_URL": {{ .Values.frontend.rootUrl | quote }}
+      {{- end }}
     }
 

--- a/nebuly-platform/templates/frontend_v2_deployment.yaml
+++ b/nebuly-platform/templates/frontend_v2_deployment.yaml
@@ -1,0 +1,106 @@
+{{- if .Values.frontend.v2.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "frontend.fullname" . }}-v2
+  namespace: {{ include "nebuly-platform.namespace" . }}
+  labels:
+    {{- include "frontend-v2.labels" . | nindent 4 }}
+  annotations:
+    {{- include "nebuly-platform.annotations" . | nindent 4 }}
+    argocd.argoproj.io/sync-wave: '5'
+spec:
+  replicas: {{ .Values.frontend.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "frontend-v2.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/frontend_configmap.yaml") . | sha256sum }}
+        {{- with .Values.frontend.podAnnotations }}
+          {{- toYaml . | nindent 6 }}
+        {{- end }}
+      labels:
+        {{- include "frontend-v2.labels" . | nindent 8 }}
+        {{- with .Values.frontend.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.frontend.podSecurityContext | nindent 8 }}
+
+      initContainers:
+        - name: populate-env-json
+          image: "{{ .Values.frontend.image.repository }}:{{ .Values.frontend.image.tag | default .Chart.AppVersion }}"
+          command: [ "/bin/sh", "-c" ]
+          args:
+            - sed "s/\${GIT_REF}/$GIT_REF/g" /env.json > /output/env.json
+          volumeMounts:
+            - name: config
+              mountPath: /env.json
+              subPath: env.json
+            - name: shared
+              mountPath: /output
+
+
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.frontend.securityContext | nindent 12 }}
+          image: "{{ .Values.frontend.v2.image.repository }}:{{ .Values.frontend.v2.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.frontend.v2.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+              protocol: TCP
+
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /env.json
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+
+          resources:
+            {{- toYaml .Values.frontend.resources | nindent 12 }}
+          volumeMounts:
+            - name: shared
+              mountPath: /app/public/env.json
+              subPath: env.json
+          {{- with .Values.frontend.volumeMounts }}
+          {{- toYaml . | nindent 14 }}
+          {{- end }}
+      volumes:
+        - name: "config"
+          configMap:
+            name: {{ include "frontend.fullname" . }}
+        - name: "shared"
+          emptyDir: { }
+      {{- with .Values.frontend.volumes }}
+      {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.frontend.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.frontend.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/nebuly-platform/templates/frontend_v2_ingress.yaml
+++ b/nebuly-platform/templates/frontend_v2_ingress.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.frontend.v2.enabled }}
+{{- if .Values.frontend.ingress.enabled -}}
+{{- $fullName := include "frontend.fullname" . -}}
+{{- $svcPort := .Values.frontend.service.port -}}
+{{- if and .Values.frontend.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.frontend.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.frontend.ingress.annotations "kubernetes.io/ingress.class" .Values.frontend.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-v2
+  namespace: {{ include "nebuly-platform.namespace" . }}
+  labels:
+    {{- include "frontend-v2.labels" . | nindent 4 }}
+  annotations:
+    {{- include "nebuly-platform.annotations" . | nindent 4 }}
+  {{- with .Values.frontend.ingress.annotations }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.frontend.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.frontend.ingress.className }}
+  {{- end }}
+  #{{- if .Values.frontend.ingress.tls }}
+  tls:
+    {{- range .Values.frontend.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ printf "v2.%s" . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}-v2
+    {{- end }}
+  #{{- end }}
+  rules:
+    {{- range .Values.frontend.ingress.hosts }}
+    - host: {{ printf "v2.%s" .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}-v2
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}-v2
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/nebuly-platform/templates/frontend_v2_ingress.yaml
+++ b/nebuly-platform/templates/frontend_v2_ingress.yaml
@@ -29,7 +29,7 @@ spec:
   {{- if and .Values.frontend.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
   ingressClassName: {{ .Values.frontend.ingress.className }}
   {{- end }}
-  #{{- if .Values.frontend.ingress.tls }}
+  {{- if .Values.frontend.ingress.tls }}
   tls:
     {{- range .Values.frontend.ingress.tls }}
     - hosts:
@@ -38,7 +38,7 @@ spec:
         {{- end }}
       secretName: {{ .secretName }}-v2
     {{- end }}
-  #{{- end }}
+  {{- end }}
   rules:
     {{- range .Values.frontend.ingress.hosts }}
     - host: {{ printf "v2.%s" .host | quote }}

--- a/nebuly-platform/templates/frontend_v2_service.yaml
+++ b/nebuly-platform/templates/frontend_v2_service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.frontend.v2.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "frontend.fullname" . }}-v2
+  namespace: {{ include "nebuly-platform.namespace" . }}
+  labels:
+    {{- include "frontend-v2.labels" . | nindent 4 }}
+  annotations:
+    {{- include "nebuly-platform.annotations" . | nindent 4 }}
+spec:
+  type: {{ .Values.frontend.service.type }}
+  ports:
+    - port: {{ .Values.frontend.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "frontend-v2.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -190,8 +190,15 @@ frontend:
   image:
     repository: ghcr.io/nebuly-ai/nebuly-frontend
     pullPolicy: IfNotPresent
-    tag: "v1.80.1"
+    tag: "v1.80.2"
 
+  v2:
+    # -- If true, enable the v1 of the frontend. This will create a separate deployment for the v1 of the frontend, which will run alongside the default one. The v1 of the frontend is used for testing new features and for gradual rollouts.
+    enabled: true
+    image:
+      repository: ghcr.io/nebuly-ai/nebuly-frontend
+      pullPolicy: IfNotPresent
+      tag: "v2.2.8"
   podAnnotations: { }
   podLabels: { }
 

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -193,7 +193,8 @@ frontend:
     tag: "v1.80.2"
 
   v2:
-    # -- If true, enable the v1 of the frontend. This will create a separate deployment for the v1 of the frontend, which will run alongside the default one. The v1 of the frontend is used for testing new features and for gradual rollouts.
+    # -- If true, enable the v2 of the frontend. 
+    # -- This will create a separate deployment, which will run alongside the default one.
     enabled: true
     image:
       repository: ghcr.io/nebuly-ai/nebuly-frontend


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nebuly-ai/codesmith/helm-charts/pr/194"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785482973&installation_id=139603015&pr_number=194&repository=nebuly-ai%2Fhelm-charts&return_to=https%3A%2F%2Fgithub.com%2Fnebuly-ai%2Fhelm-charts%2Fpull%2F194&signature=0cb8f8a249e112d4a41f1d957901b9f9269fede73cfb44d30b453d0fe189df3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default-on v2 adds ingress, TLS, and a second deployment on upgrade; backend CORS and APP_URL behavior change can affect auth redirects and browser API access until v2 DNS/certs are correct.
> 
> **Overview**
> Adds an optional **second frontend** (`frontend.v2`, **on by default**) that runs next to the existing deployment, using image tag **`v2.2.8`** and its own Service/Ingress on **`v2.<frontend-host>`** (TLS secrets suffixed **`-v2`**). Chart version is **1.97.0**; the legacy frontend image moves to **`v1.80.2`**.
> 
> When v2 is enabled, shared **`env.json`** gains **`NEXT_URL`** / **`NEXT_LEGACY_URL`**, backend **`APP_URL`** points at the v2 public URL, and **`frontend.v2.url`** is merged into backend **CORS** (always) and auth **CORS** (when origins are configured). New Helm helpers label/select the v2 workload as **`nebuly-frontend-v2`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a074f310446284453e4c7c6aef32a8adf5eedf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->