### PR TITLE
chore: add gpt-5 model

### DIFF
--- a/nebuly-platform/Chart.yaml
+++ b/nebuly-platform/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.97.2
+version: 1.97.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -1,6 +1,6 @@
 # Nebuly Platform
 
-![Version: 1.97.2](https://img.shields.io/badge/Version-1.97.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.97.3](https://img.shields.io/badge/Version-1.97.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for installing Nebuly's Platform on Kubernetes.
 
@@ -488,12 +488,8 @@ The command removes all the Kubernetes components associated with the chart and 
 | fullProcessing.settings.processingDelaySeconds | int | `0` | Seconds of delay between processing. |
 | fullProcessing.shmSize | string | `"1Gi"` | Size of the memory-backed `/dev/shm` volume mounted in the full-processing pod. Required by the processing pipeline (e.g. LLM inference) that relies on shared memory. Note: a memory-backed emptyDir counts against the container memory limit. Set to empty/null to disable the volume. |
 | imagePullSecrets | list | `[]` |  |
+| ingestion | object | `{"generateDbEvents":{"enabled":false,"endDate":"","resources":{"limits":{"memory":"512Mi"},"requests":{"cpu":"50m"}},"startDate":"","tenant":""}}` | Settings for ingestion jobs required during major platform upgrades. Keep everything disabled by default unless you're upgrading the platform to a major release. |
 | ingestion.generateDbEvents.enabled | bool | `false` | If True, deploy a CronJob to generate DB events. The CronJob is suspended and configured to never run on schedule; it must be manually triggered. |
-| ingestion.generateDbEvents.endDate | string | `""` |  |
-| ingestion.generateDbEvents.resources.limits.memory | string | `"512Mi"` |  |
-| ingestion.generateDbEvents.resources.requests.cpu | string | `"50m"` |  |
-| ingestion.generateDbEvents.startDate | string | `""` |  |
-| ingestion.generateDbEvents.tenant | string | `""` |  |
 | ingestionWorker.affinity | object | `{}` |  |
 | ingestionWorker.deploymentStrategy.type | string | `"Recreate"` |  |
 | ingestionWorker.env | object | `{}` | Example: - name: MY_ENV_VAR   value: "my-value" |
@@ -648,6 +644,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | openAi.existingSecret | object | - | Use an existing secret for the Azure OpenAI authentication. |
 | openAi.existingSecret.name | string | `""` | Name of the secret. Can be templated. |
 | openAi.gpt4oDeployment | string | `""` | For Azure OpenAI: the name of the GPT-4o deployment. For OpenAI: `gpt-4o`. |
+| openAi.gpt5Deployment | string | `""` | For Azure OpenAI: the name of the GPT-5 deployment. For OpenAI: `gpt-5`. |
 | openAi.translationDeployment | string | `""` | For Azure OpenAI: the name of the OpenAI Deployment used to translate interactions. For OpenAI: the name of the OpenAI model used to translate interactions. |
 | postUpgrade | object | `{"migrateInteractionEdits":{"enabled":false,"resources":{"limits":{"memory":"512Mi"},"requests":{"cpu":"50m"}}},"refreshRoTables":{"enabled":false,"resources":{"limits":{"memory":"512Mi"},"requests":{"cpu":"50m"}}}}` | Post-upgrade hooks settings. |
 | postUpgrade.migrateInteractionEdits | object | `{"enabled":false,"resources":{"limits":{"memory":"512Mi"},"requests":{"cpu":"50m"}}}` | If True, run a post-install job that migrates the interaction edits logs. |
@@ -682,7 +679,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | remoteAccess.sentry.environment | string | `""` | The name of the Sentry environment. |
 | remoteAccess.service | object | `{"port":80,"type":"ClusterIP"}` | Service of the remote access agent deployment. |
 | remoteAccess.tolerations | list | `[]` |  |
-| reprocessing | object | `{"interactions":{"enabled":false},"modelIssues":{"enabled":false},"modelSuggestions":{"enabled":false},"userIntelligence":{"enabled":false}}` | Settings for data reprocessing jobs required during major platform upgrades. Keep everything disabled by default unless you're upgrading the platform to a major release. |
+| reprocessing | object | `{"all":{"enabled":false},"interactions":{"enabled":false},"modelIssues":{"enabled":false},"modelSuggestions":{"enabled":false},"userIntelligence":{"enabled":false}}` | Settings for data reprocessing jobs required during major platform upgrades. Keep everything disabled by default unless you're upgrading the platform to a major release. |
 | secretsStore.azure.clientId | string | `""` | The Application ID of the Azure AD application used to access the Azure Key Vault. To be provided only when not using an existing secret (see azure.existingSecret value below). |
 | secretsStore.azure.clientSecret | string | `""` | The Application Secret of the Azure AD application used to access the Azure Key Vault. To be provided only when not using an existing secret (see azure.existingSecret value below). |
 | secretsStore.azure.existingSecret | object | - | Use an existing secret for the Azure Key Vault authentication. |

--- a/nebuly-platform/templates/_batch_jobs.tpl
+++ b/nebuly-platform/templates/_batch_jobs.tpl
@@ -54,6 +54,8 @@
   value: "{{ .Values.openAi.gpt4oDeployment }}"
 - name: OPENAI_DEPLOYMENT_GPT4O
   value: {{ .Values.openAi.gpt4oDeployment | quote }}
+- name: OPENAI_DEPLOYMENT_GPT5
+  value: {{ .Values.openAi.gpt5Deployment | quote }}
 - name: OPENAI_API_KEY
   valueFrom:
     secretKeyRef:

--- a/nebuly-platform/templates/reprocess-all_cronjob.yaml
+++ b/nebuly-platform/templates/reprocess-all_cronjob.yaml
@@ -1,0 +1,109 @@
+{{- if .Values.reprocessing.all.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: reprocess-all
+  namespace: {{ include "nebuly-platform.namespace" . }}
+  labels:
+    {{- include "primaryProcessing.commonLabels" . | nindent 4 }}
+  annotations:
+    {{- include "nebuly-platform.annotations" . | nindent 4 }}
+spec:
+  schedule: 0 0 30 2 * # Never
+  suspend: true
+  jobTemplate:
+    metadata:
+      labels:
+        {{- include "primaryProcessing.commonLabels" . | nindent 10 }}
+    spec:
+      backoffLimit: {{ .Values.primaryProcessing.backoffLimit }}
+      activeDeadlineSeconds: {{ .Values.primaryProcessing.activeDeadlineSeconds }}
+      template:
+        metadata:
+          {{- with .Values.primaryProcessing.podAnnotations }}
+          annotations:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          labels:
+            {{- include "jobProcessAll.labels" . | nindent 14 }}
+            {{- with .Values.primaryProcessing.podLabels }}
+            {{- toYaml . | nindent 14 }}
+            {{- end }}
+        spec:
+          hostIPC: {{ .Values.primaryProcessing.hostIPC }}
+          serviceAccountName: {{ .Values.serviceAccount.name }}
+          restartPolicy: Never
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.primaryProcessing.podSecurityContext | nindent 12 }}
+          containers:
+            - name: {{ .Chart.Name }}
+              securityContext:
+                {{- toYaml .Values.primaryProcessing.securityContext | nindent 16 }}
+              image: "{{ .Values.primaryProcessing.image.repository }}:{{ .Values.primaryProcessing.image.tag | default .Chart.AppVersion }}"
+              command:
+                - python
+                - minkmaze
+                - jobs
+                - complete
+                - nebuly
+                - --reprocess
+              imagePullPolicy: {{ .Values.primaryProcessing.image.pullPolicy }}
+              env:
+              {{- if .Values.primaryProcessing.env }}
+                {{- toYaml .Values.primaryProcessing.env | nindent 16 }}
+              {{- end }}
+              {{ include "ingestionWorker.commonEnv" . | nindent 16 }}
+              {{ include "batchJobs.commonEnv" . | nindent 16 }}
+              resources:
+                {{- toYaml .Values.primaryProcessing.resources | nindent 18 }}
+              volumeMounts:
+                - name: vllm-report-usage
+                  mountPath: /nonexistent
+              {{- if not .Values.kafka.external }}
+                - name: kafka-cluster-ca-cert
+                  mountPath: "/etc/kafka"
+                  readOnly: true
+              {{- end }}
+                - name: models-cache
+                  mountPath: /var/cache/nebuly
+                  readOnly: false
+              {{- include "primaryProcessing.shmVolumeMount" . | nindent 16 }}
+              {{- with .Values.primaryProcessing.volumeMounts }}
+                {{- toYaml . | nindent 18 }}
+              {{- end }}
+          volumes:
+            - name: vllm-report-usage
+              emptyDir: {}
+          {{- if not .Values.kafka.external }}
+            - name: kafka-cluster-ca-cert
+              secret:
+                secretName: {{ include "kafka.fullname" . }}-cluster-ca-cert
+          {{- end }}
+            - name: models-cache
+          {{- if .Values.primaryProcessing.modelsCache.enabled }}
+              persistentVolumeClaim:
+                claimName: {{ include "primaryProcessing.modelsCache.name" . }}
+          {{- else }}
+              emptyDir: { }
+          {{- end }}
+          {{- include "primaryProcessing.shmVolume" . | nindent 12 }}
+          {{- with .Values.primaryProcessing.volumes }}
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.primaryProcessing.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.primaryProcessing.affinity }}
+          affinity:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+          {{- with .Values.primaryProcessing.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 14 }}
+          {{- end }}
+{{- end }}

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -883,6 +883,9 @@ openAi:
   # -- For Azure OpenAI: the name of the GPT-4o deployment.
   # For OpenAI: `gpt-4o`.
   gpt4oDeployment: ""
+  # -- For Azure OpenAI: the name of the GPT-5 deployment.
+  # For OpenAI: `gpt-5`.
+  gpt5Deployment: ""
   # -- For Azure OpenAI: the name of the OpenAI Deployment used to translate interactions.
   # For OpenAI: the name of the OpenAI model used to translate interactions.
   translationDeployment: ""
@@ -1373,6 +1376,8 @@ auth:
 # everything disabled by default unless you're upgrading the platform to a major
 # release.
 reprocessing:
+  all:
+    enabled: false
   interactions:
     enabled: false
   modelSuggestions:
@@ -1381,6 +1386,10 @@ reprocessing:
     enabled: false
   userIntelligence:
     enabled: false
+
+# -- Settings for ingestion jobs required during major platform upgrades. Keep
+# everything disabled by default unless you're upgrading the platform to a major
+# release.
 ingestion:
   generateDbEvents:
     # -- If True, deploy a CronJob to generate DB events. The CronJob is suspended and


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nebuly-ai/codesmith/helm-charts/pr/196"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786016524&installation_id=139603015&pr_number=196&repository=nebuly-ai%2Fhelm-charts&return_to=https%3A%2F%2Fgithub.com%2Fnebuly-ai%2Fhelm-charts%2Fpull%2F196&signature=1bdfb2eef2eff14f11e225d6b38afb216c8f553a153ed2e8a84b69a39abffab4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> GPT-5 env wiring affects all jobs using `batchJobs.commonEnv` when deployments are set; enabling `reprocessing.all` can trigger heavy GPU reprocessing against production data.
> 
> **Overview**
> Bumps the **nebuly-platform** chart to **1.97.3** and wires **GPT-5** into Helm: new `openAi.gpt5Deployment` (Azure deployment name or `gpt-5` for OpenAI) and `OPENAI_DEPLOYMENT_GPT5` on batch/processing workloads via `batchJobs.commonEnv`.
> 
> Adds an opt-in **`reprocessing.all`** flag and a suspended **`reprocess-all`** CronJob that runs `minkmaze jobs complete nebuly --reprocess`, mirroring other upgrade reprocessing jobs (primary processing image, GPU/resources, Kafka/models cache). README values docs are refreshed for `openAi.gpt5Deployment`, `reprocessing.all`, and the `ingestion` upgrade jobs block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8556a4301c1b025d48857d43726c4cc67d2d4fed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->