### PR TITLE
fix: run pre start in module mode

### DIFF
--- a/nebuly-platform/templates/backend_deployment.yaml
+++ b/nebuly-platform/templates/backend_deployment.yaml
@@ -40,7 +40,8 @@ spec:
           imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
           command:
             - python
-            - app/backend_pre_start.py
+            - -m
+            - app.backend_pre_start
           env:
             # Common env
             {{ include "backend.commonEnv" . | nindent 12 }}


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nebuly-ai/codesmith/helm-charts/pr/197"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786092298&installation_id=139603015&pr_number=197&repository=nebuly-ai%2Fhelm-charts&return_to=https%3A%2F%2Fgithub.com%2Fnebuly-ai%2Fhelm-charts%2Fpull%2F197&signature=16edd6364a79bff567626bd4348b6cc70cbaa1985c46a360468f2d2c235843cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Helm command change for the migrations init container; no auth, data, or application logic changes.
> 
> **Overview**
> Updates the backend **migrations** init container in `backend_deployment.yaml` to start pre-migration checks with **`python -m app.backend_pre_start`** instead of **`python app/backend_pre_start.py`**.
> 
> This runs the entrypoint as a package module so imports and `PYTHONPATH` behave like the rest of the app image, which avoids failures when the script path alone does not resolve `app.*` correctly at startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cbbd9d9e74b3e8c60cadd00b0f4aa9150574dd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->