### PR TITLE
[BUILD] build: Add  SKIP_PROCESSING_FOR_PROJECTS env var

### DIFF
--- a/nebuly-platform/Chart.yaml
+++ b/nebuly-platform/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.100.0
+version: 1.100.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/nebuly-platform/README.md
+++ b/nebuly-platform/README.md
@@ -1,6 +1,6 @@
 # Nebuly Platform
 
-![Version: 1.100.0](https://img.shields.io/badge/Version-1.100.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 1.100.1](https://img.shields.io/badge/Version-1.100.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 Helm chart for installing Nebuly's Platform on Kubernetes.
 
@@ -532,6 +532,7 @@ The command removes all the Kubernetes components associated with the chart and 
 | ingestionWorker.settings.maxNumberOfGenerationLoop | int | `2` |  |
 | ingestionWorker.settings.piiDenyList | list | `[]` | List of PII keywords to be ignored. You can insert names and addresses that you don't want the PII detection to remove. |
 | ingestionWorker.settings.piiEnabledTenants | list | `[]` | List of tenants for which PII detection is enabled. Note that when given this will override the enablePiiLlm setting for the given tenants. |
+| ingestionWorker.settings.skipProcessingForProjects | list | `[]` |  |
 | ingestionWorker.settings.startDateActions | string | `"2020-01-01 00:00:00+00:00"` | Start date used to consider existing actions. This feature should only be used to force the processing pipeline to ignore actions created before a given date.  |
 | ingestionWorker.settings.startDateSubTopics | string | `"2020-01-01 00:00:00+00:00"` | Start date used to consider existing sub-topics. This feature should only be used to force the processing pipeline to ignore sub-topics created before a given date. |
 | ingestionWorker.settings.startDateTopics | string | `"2020-01-01 00:00:00+00:00"` | Start date used to consider existing topics. This feature should only be used to force the processing pipeline to ignore topics created before a given date. |

--- a/nebuly-platform/templates/_ingestion_worker.tpl
+++ b/nebuly-platform/templates/_ingestion_worker.tpl
@@ -120,6 +120,9 @@
   value: {{ .Values.ingestionWorker.settings.maxNumberOfGenerationLoop | quote }}
 - name: CATEGORY_GENERATOR_MAX_ITERATIONS
   value: {{ .Values.ingestionWorker.settings.categoryGeneratorMaxIterations | quote }}
+# Global processing settings
+- name: SKIP_PROCESSING_FOR_PROJECTS
+  value: {{ .Values.ingestionWorker.settings.skipProcessingForProjects | toJson | quote }}
 # AI Models pulling
 {{ include "aiModels.env" . }}
 {{- with .Values.ingestionWorker.env }}

--- a/nebuly-platform/values.yaml
+++ b/nebuly-platform/values.yaml
@@ -435,7 +435,7 @@ ingestionWorker:
       tags: true
     maxNumberOfGenerationLoop: 2
     categoryGeneratorMaxIterations: 5
-
+    skipProcessingForProjects: [ ]
 
   replicaCount: 1
   image:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Misconfigured project IDs could silently skip processing for live projects; behavior depends on ingestion-worker v1.79.1 reading this env var.
> 
> **Overview**
> Adds Helm support for **`SKIP_PROCESSING_FOR_PROJECTS`**, letting operators pass a list of project IDs whose ingestion/processing pipeline should be skipped.
> 
> The new value **`ingestionWorker.settings.skipProcessingForProjects`** (default `[]`) is serialized to JSON and exposed on workloads that use **`ingestionWorker.commonEnv`**, including the ingestion worker deployment and primary/full-processing jobs. Chart version is bumped to **1.100.1** and the generated README values table is updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10d29b3096cb39cc0d56c15e373db7f6d591a696. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/nebuly-ai/codesmith/helm-charts/pr/199"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789030863&installation_model_id=423910&pr_number=199&repository=nebuly-ai%2Fhelm-charts&return_to=https%3A%2F%2Fgithub.com%2Fnebuly-ai%2Fhelm-charts%2Fpull%2F199&signature=d1df584dc38ffd52c220a9d8658f0c0b46520806e75897f55652cf3205457275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->